### PR TITLE
Fixing multibyte utf8 characters splitting

### DIFF
--- a/lorem.go
+++ b/lorem.go
@@ -103,7 +103,7 @@ func Sentence(min, max int) string {
 	}
 
 	sentence := strings.Join(ws, " ") + "."
-	sentence = strings.ToUpper(sentence[:1]) + sentence[1:]
+	sentence = strings.Title(sentence)
 	return sentence
 }
 


### PR DESCRIPTION
strings.Title will fix bugs while splitting multibyte characters, and it is the default way of doing capitalization of sentences.