### PR TITLE
bugs while splitting multibyte characters

### DIFF
--- a/lorem.go
+++ b/lorem.go
@@ -102,8 +102,8 @@ func Sentence(min, max int) string {
 
 	}
 
+	ws[0] = strings.Title(ws[0])
 	sentence := strings.Join(ws, " ") + "."
-	sentence = strings.ToUpper(sentence[:1]) + sentence[1:]
 	return sentence
 }
 


### PR DESCRIPTION
strings.Title will fix bugs while splitting multibyte characters, and it is the default way of doing capitalization of sentences.